### PR TITLE
Adding (plugin)repository in pom.xml

### DIFF
--- a/source/writing-renjin-extensions.rst
+++ b/source/writing-renjin-extensions.rst
@@ -128,6 +128,14 @@ packages:
             </repository>
         </repositories>
 
+        <pluginRepositories>
+            <pluginRepository>
+                <id>bedatadriven</id>
+                <name>bedatadriven public repo</name>
+                <url>http://nexus.bedatadriven.com/content/groups/public/</url>
+            </pluginRepository>
+        </pluginRepositories>
+
         <build>
             <plugins>
                 <plugin>


### PR DESCRIPTION
I wanted to create an own extension but the given pom.xml is missing the (plugin)repository for ```renjin-maven-plugin```.

According to https://cwiki.apache.org/confluence/display/MAVEN/PluginResolutionException point 2, build plugins have their own repository structure.