### PR TITLE
Add location of javadocs to the text

### DIFF
--- a/source/renjin-java-api-specification.rst
+++ b/source/renjin-java-api-specification.rst
@@ -3,7 +3,7 @@ Renjin Java API specification
 
 This chapter includes a selection of public classes and methods in some of
 Renjin's Java packages which are most useful to users of Renjin looking to
-exchange data between Java and R code.
+exchange data between Java and R code. The java docs for renjin is available as http://javadoc.renjin.org/.
 
 org.renjin.sexp
 ---------------


### PR DESCRIPTION
The javadoc location is hard to find. Would be nice to include it in the text here.